### PR TITLE
Mark several additional user fields as optional

### DIFF
--- a/plex-api/Cargo.toml
+++ b/plex-api/Cargo.toml
@@ -17,7 +17,7 @@ serde_json = "1.0"
 quick-xml = { version = "0.21", features = [ "serialize" ] }
 serde_with = "1.6"
 serde_repr = "0.1"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4.10", features = ["serde"] }
 lazy_static = "1.4"
 url = { version = "2.2", features = ["serde"] }
 async-trait = "0.1"

--- a/plex-api/src/my_plex/mod.rs
+++ b/plex-api/src/my_plex/mod.rs
@@ -90,7 +90,7 @@ pub struct MyPlexAccount {
     mailing_list_status: String,
     mailing_list_active: bool,
     scrobble_types: String,
-    pin: String,
+    pin: Option<String>,
     subscription: SubscriptionSummary,
     subscription_description: String,
     restricted: bool,
@@ -112,11 +112,11 @@ pub struct MyPlexAccount {
     country: String,
     home_admin: bool,
     trials: Vec<String>,
-    ads_consent: bool,
-    #[serde(with = "chrono::serde::ts_seconds")]
-    ads_consent_set_at: DateTime<Utc>,
-    #[serde(with = "chrono::serde::ts_seconds")]
-    ads_consent_reminder_at: DateTime<Utc>,
+    ads_consent: Option<bool>,
+    #[serde(with = "chrono::serde::ts_seconds_option")]
+    ads_consent_set_at: Option<DateTime<Utc>>,
+    #[serde(with = "chrono::serde::ts_seconds_option")]
+    ads_consent_reminder_at: Option<DateTime<Utc>>,
     anonymous: Option<bool>,
 }
 


### PR DESCRIPTION
My user object does not have these fields set, and so logging in as myself fails. The `ts_seconds_option` helper in chrono was only added in 0.4.10, so bump the minimum version to ensure it's there.