### PR TITLE
Add some missing fields to AudioStream struct

### DIFF
--- a/plex-api/src/media_container/media/stream.rs
+++ b/plex-api/src/media_container/media/stream.rs
@@ -58,6 +58,14 @@ struct MediaStreamStruct {
         deserialize_with = "crate::serde_helpers::option_bool_from_anything"
     )]
     embedded_in_video: Option<bool>,
+    extended_display_title: Option<String>,
+    album_gain: Option<f32>,
+    album_peak: Option<f32>,
+    album_range: Option<f32>,
+    gain: Option<f32>,
+    loudness: Option<f32>,
+    lra: Option<f32>,
+    peak: Option<f32>,
 }
 
 macro_rules! media_stream_enum {
@@ -137,13 +145,22 @@ media_stream_enum! {
 
 media_stream_enum! {
     pub struct AudioStream {
-        default: bool,
+        default: Option<bool>,
         selected: bool,
         bitrate: u32,
         profile: String,
         sampling_rate: u32,
         channels: u8,
         audio_channel_layout: String,
+        album_gain: Option<f32>,
+        album_peak: Option<f32>,
+        album_range: Option<f32>,
+        bit_depth: Option<u16>,
+        extended_display_title: Option<String>,
+        gain: Option<f32>,
+        loudness: Option<f32>,
+        lra: Option<f32>,
+        peak: Option<f32>,
     }
 }
 

--- a/plex-api/src/media_container/mod.rs
+++ b/plex-api/src/media_container/mod.rs
@@ -46,4 +46,5 @@ pub enum MediaType {
     Photo,
     Episode,
     Season,
+    Track,
 }


### PR DESCRIPTION
Audio streams from music libraries have several additional fields which aren't present in audio streams from movies/TV. Add them for completeness:

```[
  {
    "audioChannels": "2",
    "audioCodec": "flac",
    "bitrate": "807",
    "container": "flac",
    "duration": "404391",
    "id": "42467",
    "Part": [
      {
        "container": "flac",
        "duration": "404391",
        "file": "/data/Music/Stephen Encinas/flac_Stephen_Encinas-Disco_Illusion/1-Disco_Illusion.flac",
        "id": "42477",
        "key": "/library/parts/42477/1612402403/file.flac",
        "size": "40814138",
        "Stream": [
          {
            "albumGain": "-7.13",
            "albumPeak": "0.988617",
            "albumRange": "4.366412",
            "audioChannelLayout": "stereo",
            "bitDepth": "16",
            "bitrate": "807",
            "channels": "2",
            "codec": "flac",
            "displayTitle": "FLAC (Stereo)",
            "extendedDisplayTitle": "FLAC (Stereo)",
            "gain": "-7.13",
            "id": "102280",
            "index": "0",
            "loudness": "-10.87",
            "lra": "5.48",
            "peak": "0.988617",
            "samplingRate": "44100",
            "selected": "1",
            "streamType": "2"
          }
        ]
      }
    ]
  }
]```