### PR TITLE
fix: certificateVersion is not returned from the myplex API

### DIFF
--- a/crates/plex-api/src/myplex/account.rs
+++ b/crates/plex-api/src/myplex/account.rs
@@ -101,7 +101,6 @@ pub struct MyPlexAccount {
     pub queue_uid: Option<HashMap<String, String>>,
     pub home_size: i32,
     pub max_home_size: i32,
-    pub certificate_version: i32,
     #[serde(with = "time::serde::timestamp::option")]
     pub remember_expires_at: Option<OffsetDateTime>,
     pub profile: Profile,

--- a/crates/plex-api/tests/mocks/myplex/api/v2/user/user_info_free.json
+++ b/crates/plex-api/tests/mocks/myplex/api/v2/user/user_info_free.json
@@ -80,7 +80,6 @@
     "homeSize": 1,
     "homeAdmin": false,
     "maxHomeSize": 15,
-    "certificateVersion": 3,
     "rememberExpiresAt": 1642415212,
     "profile": {
         "autoSelectAudio": true,

--- a/crates/plex-api/tests/mocks/myplex/api/v2/user/user_info_free_guest.json
+++ b/crates/plex-api/tests/mocks/myplex/api/v2/user/user_info_free_guest.json
@@ -117,7 +117,6 @@
     "homeSize": 5,
     "homeAdmin": false,
     "maxHomeSize": 15,
-    "certificateVersion": 3,
     "rememberExpiresAt": null,
     "profile": {
         "autoSelectAudio": true,

--- a/crates/plex-api/tests/mocks/myplex/api/v2/user/user_info_plexpass.json
+++ b/crates/plex-api/tests/mocks/myplex/api/v2/user/user_info_plexpass.json
@@ -151,7 +151,6 @@
     "homeSize": 3,
     "homeAdmin": true,
     "maxHomeSize": 15,
-    "certificateVersion": 3,
     "rememberExpiresAt": 1641937035,
     "profile": {
         "autoSelectAudio": true,

--- a/crates/plex-api/tests/mocks/myplex/api/v2/user/user_info_plexpass_guest.json
+++ b/crates/plex-api/tests/mocks/myplex/api/v2/user/user_info_plexpass_guest.json
@@ -128,7 +128,6 @@
     "homeSize": 3,
     "homeAdmin": false,
     "maxHomeSize": 15,
-    "certificateVersion": 3,
     "rememberExpiresAt": 1641937035,
     "profile": {
         "autoSelectAudio": true,

--- a/crates/plex-api/tests/myplex.rs
+++ b/crates/plex-api/tests/myplex.rs
@@ -155,3 +155,17 @@ mod offline {
         );
     }
 }
+
+mod online {
+    use super::fixtures::online::client::*;
+    use plex_api::{HttpClient, MyPlexBuilder};
+
+    #[plex_api_test_helper::online_test_claimed_server]
+    async fn connect(client_authenticated: HttpClient) {
+        MyPlexBuilder::default()
+            .set_client(client_authenticated)
+            .build()
+            .await
+            .unwrap();
+    }
+}


### PR DESCRIPTION
I'm not sure if this was removed at some point or what but the API no longer returns this field.