### PR TITLE
Remove enum-utils dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 3
 
 [[package]]
-name = "addr2line"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
-dependencies = [
- "gimli",
-]
-
-[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,21 +223,6 @@ name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
-
-[[package]]
-name = "backtrace"
-version = "0.3.66"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab84319d616cfb654d03394f38ab7e6f0919e181b1b57e1fd15e7fb4077d9a7"
-dependencies = [
- "addr2line",
- "cc",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
-]
 
 [[package]]
 name = "base64"
@@ -574,43 +550,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "enum-utils"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed327f716d0d351d86c9fd3398d20ee39ad8f681873cc081da2ca1c10fed398a"
-dependencies = [
- "enum-utils-from-str",
- "failure",
- "proc-macro2",
- "quote",
- "serde_derive_internals",
- "syn",
-]
-
-[[package]]
-name = "enum-utils-from-str"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d49be08bad6e4ca87b2b8e74146987d4e5cb3b7512efa50ef505b51a22227ee1"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
 name = "event-listener"
 version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
-
-[[package]]
-name = "failure"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
-dependencies = [
- "backtrace",
-]
 
 [[package]]
 name = "fastrand"
@@ -783,12 +726,6 @@ dependencies = [
  "libc",
  "wasi",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
 
 [[package]]
 name = "gloo-timers"
@@ -1253,15 +1190,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1398,7 +1326,6 @@ version = "0.0.4"
 dependencies = [
  "async-std",
  "cargo-husky",
- "enum-utils",
  "futures",
  "http",
  "http-serde",
@@ -1623,12 +1550,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
-
-[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1727,17 +1648,6 @@ name = "serde_derive"
 version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "serde_derive_internals"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dbab34ca63057a1f15280bdf3c39f2b1eb1b54c17e98360e511637aef7418c6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/plex-api/Cargo.toml
+++ b/crates/plex-api/Cargo.toml
@@ -27,7 +27,6 @@ serde_urlencoded = "^0.7.1"
 thiserror = "^1.0"
 sys-info = "^0.9"
 monostate = "^0.1.1"
-enum-utils = "^0.1.2"
 serde-aux = "^4.0.0"
 
 [build-dependencies]

--- a/crates/plex-api/src/media_container/server/library.rs
+++ b/crates/plex-api/src/media_container/server/library.rs
@@ -1,5 +1,4 @@
-use std::str::FromStr;
-
+use crate::media_container::MediaContainer;
 use monostate::MustBe;
 use serde::{Deserialize, Deserializer};
 use serde_aux::prelude::{
@@ -7,9 +6,8 @@ use serde_aux::prelude::{
     deserialize_option_number_from_string,
 };
 use serde_json::Value;
+use serde_plain::derive_fromstr_from_deserialize;
 use time::{Date, OffsetDateTime};
-
-use crate::media_container::MediaContainer;
 
 fn optional_boolish<'de, D>(deserializer: D) -> Result<Option<bool>, D::Error>
 where
@@ -18,34 +16,21 @@ where
     Ok(Some(deserialize_bool_from_anything(deserializer)?))
 }
 
-#[derive(Debug, Clone, Deserialize, enum_utils::FromStr)]
-#[enumeration(rename_all = "lowercase")]
-#[serde(from = "String")]
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum ChapterSource {
     Media,
     Mixed,
     Agent,
-    #[enumeration(skip)]
-    Unknown(String),
+    #[cfg(not(feature = "tests_deny_unknown_fields"))]
+    #[serde(other)]
+    Unknown,
 }
 
-impl From<String> for ChapterSource {
-    fn from(s: String) -> Self {
-        match Self::from_str(&s) {
-            Ok(v) => v,
-            Err(_) => {
-                if cfg!(feature = "tests_deny_unknown_fields") {
-                    panic!("Failed to parse chapter source {}", s);
-                }
-                Self::Unknown(s)
-            }
-        }
-    }
-}
+derive_fromstr_from_deserialize!(ChapterSource);
 
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq, enum_utils::FromStr)]
-#[enumeration(rename_all = "kebab-case")]
-#[serde(from = "String")]
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
 pub enum AudioCodec {
     Aac,
     Ac3,
@@ -57,27 +42,15 @@ pub enum AudioCodec {
     Opus,
     Pcm,
     Vorbis,
-    #[enumeration(skip)]
-    Unknown(String),
+    #[cfg(not(feature = "tests_deny_unknown_fields"))]
+    #[serde(other)]
+    Unknown,
 }
 
-impl From<String> for AudioCodec {
-    fn from(s: String) -> Self {
-        match Self::from_str(&s) {
-            Ok(v) => v,
-            Err(_) => {
-                if cfg!(feature = "tests_deny_unknown_fields") {
-                    panic!("Failed to parse audio codec {}", s);
-                }
-                Self::Unknown(s)
-            }
-        }
-    }
-}
+derive_fromstr_from_deserialize!(AudioCodec);
 
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq, enum_utils::FromStr)]
-#[enumeration(rename_all = "kebab-case")]
-#[serde(from = "String")]
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
 pub enum VideoCodec {
     H264,
     Hevc,
@@ -88,27 +61,15 @@ pub enum VideoCodec {
     Vc1,
     Vp8,
     Vp9,
-    #[enumeration(skip)]
-    Unknown(String),
+    #[cfg(not(feature = "tests_deny_unknown_fields"))]
+    #[serde(other)]
+    Unknown,
 }
 
-impl From<String> for VideoCodec {
-    fn from(s: String) -> Self {
-        match Self::from_str(&s) {
-            Ok(v) => v,
-            Err(_) => {
-                if cfg!(feature = "tests_deny_unknown_fields") {
-                    panic!("Failed to parse video vodec {}", s);
-                }
-                Self::Unknown(s)
-            }
-        }
-    }
-}
+derive_fromstr_from_deserialize!(VideoCodec);
 
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq, enum_utils::FromStr)]
-#[enumeration(rename_all = "lowercase")]
-#[serde(from = "String")]
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
 pub enum ContainerFormat {
     Aac,
     Avi,
@@ -119,23 +80,12 @@ pub enum ContainerFormat {
     Mp4,
     Mpeg,
     MpegTs,
-    #[enumeration(skip)]
-    Unknown(String),
+    #[cfg(not(feature = "tests_deny_unknown_fields"))]
+    #[serde(other)]
+    Unknown,
 }
 
-impl From<String> for ContainerFormat {
-    fn from(s: String) -> Self {
-        match Self::from_str(&s) {
-            Ok(v) => v,
-            Err(_) => {
-                if cfg!(feature = "tests_deny_unknown_fields") {
-                    panic!("Failed to parse container format {}", s);
-                }
-                Self::Unknown(s)
-            }
-        }
-    }
-}
+derive_fromstr_from_deserialize!(ContainerFormat);
 
 #[derive(Debug, Deserialize, Clone)]
 #[cfg_attr(feature = "tests_deny_unknown_fields", serde(deny_unknown_fields))]
@@ -261,9 +211,8 @@ pub struct GrandParentMetadata {
     pub grandparent_theme: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Clone, enum_utils::FromStr)]
-#[enumeration(rename_all = "lowercase")]
-#[serde(from = "String")]
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "lowercase")]
 pub enum MetadataType {
     Movie,
     Episode,
@@ -275,23 +224,12 @@ pub enum MetadataType {
     Season,
     Track,
     Playlist,
-    #[enumeration(skip)]
-    Unknown(String),
+    #[cfg(not(feature = "tests_deny_unknown_fields"))]
+    #[serde(other)]
+    Unknown,
 }
 
-impl From<String> for MetadataType {
-    fn from(s: String) -> Self {
-        match Self::from_str(&s) {
-            Ok(v) => v,
-            Err(_) => {
-                if cfg!(feature = "tests_deny_unknown_fields") {
-                    panic!("Failed to parse metadata type {}", s);
-                }
-                Self::Unknown(s)
-            }
-        }
-    }
-}
+derive_fromstr_from_deserialize!(MetadataType);
 
 #[derive(Debug, Deserialize, Clone)]
 #[cfg_attr(feature = "tests_deny_unknown_fields", serde(deny_unknown_fields))]
@@ -454,30 +392,18 @@ pub struct MetadataMediaContainer {
     pub metadata: Vec<Metadata>,
 }
 
-#[derive(Debug, Deserialize, Clone, enum_utils::FromStr)]
-#[enumeration(rename_all = "lowercase")]
-#[serde(from = "String")]
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "lowercase")]
 pub enum PivotType {
     Hub,
     List,
     View,
-    #[enumeration(skip)]
-    Unknown(String),
+    #[cfg(not(feature = "tests_deny_unknown_fields"))]
+    #[serde(other)]
+    Unknown,
 }
 
-impl From<String> for PivotType {
-    fn from(s: String) -> Self {
-        match Self::from_str(&s) {
-            Ok(v) => v,
-            Err(_) => {
-                if cfg!(feature = "tests_deny_unknown_fields") {
-                    panic!("Failed to parse pivot type {}", s);
-                }
-                Self::Unknown(s)
-            }
-        }
-    }
-}
+derive_fromstr_from_deserialize!(PivotType);
 
 #[derive(Debug, Deserialize, Clone)]
 #[cfg_attr(feature = "tests_deny_unknown_fields", serde(deny_unknown_fields))]
@@ -492,31 +418,19 @@ pub struct Pivot {
     pub pivot_type: PivotType,
 }
 
-#[derive(Debug, Deserialize, Clone, enum_utils::FromStr)]
-#[enumeration(rename_all = "lowercase")]
-#[serde(from = "String")]
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "lowercase")]
 pub enum LibraryType {
     Movie,
     Show,
     Artist,
     Photo,
-    #[enumeration(skip)]
-    Unknown(String),
+    #[cfg(not(feature = "tests_deny_unknown_fields"))]
+    #[serde(other)]
+    Unknown,
 }
 
-impl From<String> for LibraryType {
-    fn from(s: String) -> Self {
-        match Self::from_str(&s) {
-            Ok(v) => v,
-            Err(_) => {
-                if cfg!(feature = "tests_deny_unknown_fields") {
-                    panic!("Failed to parse library type {}", s);
-                }
-                Self::Unknown(s)
-            }
-        }
-    }
-}
+derive_fromstr_from_deserialize!(LibraryType);
 
 #[derive(Debug, Deserialize, Clone)]
 #[cfg_attr(feature = "tests_deny_unknown_fields", serde(deny_unknown_fields))]

--- a/crates/plex-api/src/server/library.rs
+++ b/crates/plex-api/src/server/library.rs
@@ -622,7 +622,8 @@ impl Library {
             LibraryType::Show => Library::TV(TVLibrary { client, directory }),
             LibraryType::Artist => Library::Music(MusicLibrary { client, directory }),
             LibraryType::Photo => Library::Photo(PhotoLibrary { client, directory }),
-            LibraryType::Unknown(t) => panic!("Unknown library type {}", t),
+            #[cfg(not(feature = "tests_deny_unknown_fields"))]
+            LibraryType::Unknown => panic!("Unknown library type"),
         }
     }
 

--- a/crates/plex-api/src/server/mod.rs
+++ b/crates/plex-api/src/server/mod.rs
@@ -2,13 +2,12 @@ pub mod library;
 pub mod prefs;
 
 use self::{library::Library, prefs::Preferences};
+#[cfg(not(feature = "tests_deny_unknown_fields"))]
+use crate::media_container::server::library::LibraryType;
 use crate::{
     http_client::HttpClient,
     media_container::{
-        server::{
-            library::{ContentDirectory, LibraryType},
-            MediaProviderFeature, Server as ServerMediaContainer,
-        },
+        server::{library::ContentDirectory, MediaProviderFeature, Server as ServerMediaContainer},
         MediaContainerWrapper,
     },
     myplex::MyPlex,
@@ -89,7 +88,8 @@ impl Server {
                 .iter()
                 .filter_map(|d| match d {
                     ContentDirectory::Media(lib) => match lib.library_type {
-                        LibraryType::Unknown(_) => None,
+                        #[cfg(not(feature = "tests_deny_unknown_fields"))]
+                        LibraryType::Unknown => None,
                         _ => Some(Library::new(self.client.clone(), *lib.clone())),
                     },
                     _ => None,


### PR DESCRIPTION
`enum-utils` is not updated for a while now, and it depends on the `failure` crate with unresolved security vulnerabilities.

Unfortunately, the current implementation removes the String value from some of the `Unknown` variants in the library-related enums. I hope to find a way to save those before merging.