### PR TITLE
refactor: pass http_client by reference in media

### DIFF
--- a/crates/plex-api/Cargo.toml
+++ b/crates/plex-api/Cargo.toml
@@ -8,7 +8,7 @@ description = "Library for communication with Plex server. Work in progress, not
 license = "MIT/Apache-2.0"
 repository = "https://github.com/andrey-yantsen/plex-api.rs"
 readme = "../../README.md"
-rust-version = "1.61.0"
+rust-version = "1.62.0"
 
 [dependencies]
 isahc = { version = "^1.7.2", features = ["json", "text-decoding"] }

--- a/crates/plex-api/src/server/mod.rs
+++ b/crates/plex-api/src/server/mod.rs
@@ -82,7 +82,7 @@ impl Server {
                     ContentDirectory::Media(lib) => match lib.library_type {
                         #[cfg(not(feature = "tests_deny_unknown_fields"))]
                         LibraryType::Unknown => None,
-                        _ => Some(Library::new(self.client.clone(), *lib.clone())),
+                        _ => Some(Library::new(&self.client, *lib.clone())),
                     },
                     _ => None,
                 })


### PR DESCRIPTION
Having the media objects without a valid server connection doesn't seem reasonable, so let's reduce the number of memory allocations and use a reference for the HTTP Client inside the Media objects.

@Mossop, what do you think about this?