### PR TITLE
fix: Allow more unknown data to be deserialized without failing.

### DIFF
--- a/crates/plex-api/src/media_container/server/library.rs
+++ b/crates/plex-api/src/media_container/server/library.rs
@@ -504,4 +504,6 @@ pub enum ContentDirectory {
     Media(Box<ServerLibrary>),
     #[serde(rename_all = "camelCase")]
     Home(ServerHome),
+    // A fallback for any unexpected data.
+    Unknown(Value),
 }

--- a/crates/plex-api/src/media_container/server/mod.rs
+++ b/crates/plex-api/src/media_container/server/mod.rs
@@ -80,6 +80,8 @@ pub enum MediaProviderFeature {
 pub enum MediaProviderProtocol {
     Stream,
     Download,
+    #[serde(other)]
+    Unknown,
 }
 
 derive_fromstr_from_deserialize!(MediaProviderProtocol);

--- a/crates/plex-api/src/media_container/server/mod.rs
+++ b/crates/plex-api/src/media_container/server/mod.rs
@@ -102,6 +102,7 @@ derive_fromstr_from_deserialize!(MediaProviderType);
 #[serde(rename_all = "camelCase")]
 pub struct MediaProvider {
     pub identifier: String,
+    pub id: Option<u32>,
     #[serde_as(as = "StringWithSeparator::<CommaSeparator, MediaProviderProtocol>")]
     pub protocols: Vec<MediaProviderProtocol>,
     pub title: String,
@@ -109,6 +110,11 @@ pub struct MediaProvider {
     pub types: Vec<MediaProviderType>,
     #[serde(rename = "Feature")]
     pub features: Vec<MediaProviderFeature>,
+    #[serde(rename = "parentID")]
+    pub parent_id: Option<u32>,
+    pub provider_identifier: Option<String>,
+    pub epg_source: Option<String>,
+    pub friendly_name: Option<String>,
 }
 
 #[serde_as]

--- a/crates/plex-api/tests/mocks/server/media/providers_plexpass.json
+++ b/crates/plex-api/tests/mocks/server/media/providers_plexpass.json
@@ -267,6 +267,199 @@
                         "type": "subscribe"
                     }
                 ]
+            },
+            {
+                "id": 31,
+                "parentID": 30,
+                "identifier": "tv.plex.providers.epg.cloud:30",
+                "providerIdentifier": "tv.plex.providers.epg.cloud",
+                "title": "Live TV & DVR",
+                "types": "video",
+                "protocols": "livetv",
+                "epgSource": "Gracenote",
+                "friendlyName": "Mandelbrot",
+                "Feature": [
+                    {
+                        "key": "/tv.plex.providers.epg.cloud:30/sections",
+                        "type": "content",
+                        "Directory": [
+                            {
+                                "id": "tv.plex.providers.epg.cloud:30",
+                                "hubKey": "/tv.plex.providers.epg.cloud:30/hubs/discover",
+                                "title": "Live TV & DVR",
+                                "Pivot": [
+                                    {
+                                        "id": "dvr.whatson",
+                                        "key": "/tv.plex.providers.epg.cloud:30/hubs/discover",
+                                        "type": "hub",
+                                        "title": "What's On",
+                                        "context": "content.dvr.discover",
+                                        "symbol": "star"
+                                    },
+                                    {
+                                        "id": "dvr.guide",
+                                        "key": "view://dvr/guide",
+                                        "type": "view",
+                                        "title": "Guide",
+                                        "context": "content.dvr.guide",
+                                        "symbol": "guide"
+                                    },
+                                    {
+                                        "id": "dvr.schedule",
+                                        "key": "view://dvr/recording-schedule",
+                                        "type": "view",
+                                        "title": "DVR Schedule",
+                                        "context": "content.dvr.schedule",
+                                        "symbol": "schedule"
+                                    },
+                                    {
+                                        "id": "dvr.priority",
+                                        "key": "view://dvr/recording-priority",
+                                        "type": "view",
+                                        "title": "Recording Priority",
+                                        "context": "content.dvr.priority",
+                                        "symbol": "list"
+                                    },
+                                    {
+                                        "id": "dvr.browse",
+                                        "key": "/tv.plex.providers.epg.cloud:30/sections/2/all?type=4",
+                                        "type": "list",
+                                        "title": "Browse",
+                                        "context": "content.dvr.browse",
+                                        "symbol": "library"
+                                    }
+                                ]
+                            },
+                            {
+                                "type": "mixed",
+                                "key": "/tv.plex.providers.epg.cloud:30/watchnow",
+                                "title": "Guide",
+                                "icon": "/:/resources/dvr/dvr-watchnow-icon.png"
+                            },
+                            {
+                                "key": "/tv.plex.providers.epg.cloud:30/sections/1",
+                                "type": "movie",
+                                "title": "Movies",
+                                "icon": "/:/resources/dvr/dvr-movies-icon.png",
+                                "updatedAt": 1677258333
+                            },
+                            {
+                                "key": "/tv.plex.providers.epg.cloud:30/sections/2",
+                                "type": "show",
+                                "title": "Shows",
+                                "icon": "/:/resources/dvr/dvr-allshows-icon.png",
+                                "updatedAt": 1677258333
+                            },
+                            {
+                                "key": "/tv.plex.providers.epg.cloud:30/sections/3",
+                                "type": "show",
+                                "title": "Sports",
+                                "icon": "/:/resources/dvr/dvr-sports-icon.png",
+                                "updatedAt": 1677258334
+                            }
+                        ]
+                    },
+                    {
+                        "key": "/tv.plex.providers.epg.cloud:30/hubs/search",
+                        "type": "search"
+                    },
+                    {
+                        "key": "/tv.plex.providers.epg.cloud:30/matches",
+                        "type": "match"
+                    },
+                    {
+                        "key": "/tv.plex.providers.epg.cloud:30/metadata",
+                        "type": "metadata"
+                    },
+                    {
+                        "key": "/photo/:/transcode",
+                        "type": "imagetranscoder"
+                    },
+                    {
+                        "key": "/tv.plex.providers.epg.cloud:30/hubs/discover?promoted=1&includeTypeFirst=1",
+                        "type": "promoted"
+                    },
+                    {
+                        "key": "/tv.plex.providers.epg.cloud:30/grid",
+                        "type": "grid",
+                        "GridChannelFilter": [
+                            {
+                                "key": "/tv.plex.providers.epg.cloud:30/lineups/dvr/channels?genre=genre_6006cc1a610ee2002c74f34a",
+                                "title": "Entertainment",
+                                "genreRatingKey": "genre_6006cc1a610ee2002c74f34a"
+                            },
+                            {
+                                "key": "/tv.plex.providers.epg.cloud:30/lineups/dvr/channels?genre=genre_620143f98578b9238e1cdb89",
+                                "title": "Movies",
+                                "genreRatingKey": "genre_620143f98578b9238e1cdb89"
+                            },
+                            {
+                                "key": "/tv.plex.providers.epg.cloud:30/lineups/dvr/channels?genre=genre_6006cc1d610ee2002c74f38c",
+                                "title": "Reality",
+                                "genreRatingKey": "genre_6006cc1d610ee2002c74f38c"
+                            },
+                            {
+                                "key": "/tv.plex.providers.epg.cloud:30/lineups/dvr/channels?genre=genre_6074b802507c8d42cf7e103e",
+                                "title": "News + Opinion",
+                                "genreRatingKey": "genre_6074b802507c8d42cf7e103e"
+                            },
+                            {
+                                "key": "/tv.plex.providers.epg.cloud:30/lineups/dvr/channels?genre=genre_6074b802507c8d42cf7e1678",
+                                "title": "Kids + Family",
+                                "genreRatingKey": "genre_6074b802507c8d42cf7e1678"
+                            },
+                            {
+                                "key": "/tv.plex.providers.epg.cloud:30/lineups/dvr/channels?genre=genre_620143f98578b9238e1cdb88",
+                                "title": "Lifestyle",
+                                "genreRatingKey": "genre_620143f98578b9238e1cdb88"
+                            },
+                            {
+                                "key": "/tv.plex.providers.epg.cloud:30/lineups/dvr/channels?genre=genre_620143f98578b9238e1cdb8a",
+                                "title": "Sports",
+                                "genreRatingKey": "genre_620143f98578b9238e1cdb8a"
+                            },
+                            {
+                                "key": "/tv.plex.providers.epg.cloud:30/lineups/dvr/channels?genre=genre_6074b802507c8d42cf7e22eb",
+                                "title": "Explore",
+                                "genreRatingKey": "genre_6074b802507c8d42cf7e22eb"
+                            },
+                            {
+                                "key": "/tv.plex.providers.epg.cloud:30/lineups/dvr/channels?genre=genre_6006cc18610ee2002c74f2f9",
+                                "title": "Comedy",
+                                "genreRatingKey": "genre_6006cc18610ee2002c74f2f9"
+                            },
+                            {
+                                "key": "/tv.plex.providers.epg.cloud:30/lineups/dvr/channels?genre=genre_6006cc1c610ee2002c74f378",
+                                "title": "Music",
+                                "genreRatingKey": "genre_6006cc1c610ee2002c74f378"
+                            },
+                            {
+                                "key": "/tv.plex.providers.epg.cloud:30/lineups/dvr/channels?genre=genre_60d37385f631b9aabb67bf37",
+                                "title": "Gaming + Anime",
+                                "genreRatingKey": "genre_60d37385f631b9aabb67bf37"
+                            },
+                            {
+                                "key": "/tv.plex.providers.epg.cloud:30/lineups/dvr/channels?genre=genre_6171e01d4c451f5a44debdf6",
+                                "title": "En Español",
+                                "genreRatingKey": "genre_6171e01d4c451f5a44debdf6"
+                            }
+                        ]
+                    },
+                    {
+                        "key": "/tv.plex.providers.epg.cloud:30/collections",
+                        "type": "collection"
+                    },
+                    {
+                        "scrobbleKey": "/:/scrobble",
+                        "unscrobbleKey": "/:/unscrobble",
+                        "key": "/:/timeline",
+                        "type": "timeline"
+                    },
+                    {
+                        "flavor": "record",
+                        "type": "subscribe"
+                    }
+                ]
             }
         ]
     }


### PR DESCRIPTION
I added live TV to my server yesterday and discovered that now the API fails to deserialize the added content directory making the API unusable. While it might be nice to add explicit support for that in the future this adds some additional fallbacks to handle unexpected data that allows the API to work again.