### PR TITLE
fix: Make a number of already exposed types publicly usable.

### DIFF
--- a/crates/plex-api/src/lib.rs
+++ b/crates/plex-api/src/lib.rs
@@ -13,9 +13,13 @@ pub use error::Error;
 pub use http_client::{HttpClient, HttpClientBuilder};
 pub use media_container::{
     devices::Feature,
-    preferences::Value as SettingValue,
+    preferences::{Setting, SettingEnumValue, Value as SettingValue},
     server::{
-        library::{AudioCodec, ContainerFormat, Decision, Protocol, SubtitleCodec, VideoCodec},
+        library::{
+            AudioCodec, ContainerFormat, Decision, Field, GrandParentMetadata, Guid, Location,
+            Media as MediaMetadata, Metadata, MetadataType, ParentMetadata, Part as PartMetadata,
+            PlaylistType, Protocol, Rating, Role, SubtitleCodec, Tag, VideoCodec,
+        },
         Feature as ServerFeature, MappingState as ServerMappingState,
     },
 };
@@ -25,12 +29,15 @@ pub use myplex::{
 pub use player::Player;
 pub use server::{
     library::{
-        Artist, Collection, Episode, Item, Library, MediaItem, MetadataItem, Movie, MusicAlbum,
-        Photo, PhotoAlbum, PhotoAlbumItem, Playlist, Season, Show, Track, Video,
+        Artist, Collection, Episode, Item, Library, Media, MediaItem, MediaItemWithTranscoding,
+        MetadataItem, Movie, MusicAlbum, Part, Photo, PhotoAlbum, PhotoAlbumItem, Playlist, Season,
+        Show, Track, Video,
     },
+    prefs::Preferences,
     transcode::{
         ArtTranscodeOptions, AudioSetting, Constraint, Limitation, MusicTranscodeOptions,
-        TranscodeSession, TranscodeStatus, VideoSetting, VideoTranscodeOptions,
+        TranscodeSession, TranscodeSessionStats, TranscodeStatus, VideoSetting,
+        VideoTranscodeOptions,
     },
     Server,
 };

--- a/crates/plex-api/src/server/library.rs
+++ b/crates/plex-api/src/server/library.rs
@@ -181,6 +181,7 @@ pub struct Part<'a, M: MediaItem> {
 
 impl<'a, M: MediaItem> Part<'a, M> {
     /// The length of this file on disk in bytes.
+    #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> Option<u64> {
         self.part.size
     }


### PR DESCRIPTION
There are a number of types that we return in the public API but are not themselves visible outside the crate. See for example the `Metadata` struct returned here: https://docs.rs/plex-api/latest/plex_api/trait.MetadataItem.html#tymethod.metadata. The type itself is defined as public but it is inside a private module. These types can still be used to a certain extent from outside the crate but you can't `use` them for easy referencing and as such for enums you can't match on them.

This doesn't fix all of the cases but it fixes a bunch. It doesn't seem that there is a lint to detect this which surprises me so it was a bit of a manual process find them.

In this case I have exposed them at the top level. That does pollute the top-level somewhat. An alternative would be to make some of the modules public, though we may then want to restrict some of the things in those modules further. Let me know what you prefer.