### PR TITLE
fix: Send a unique X-Plex-Session-Identifier with each transcode request

### DIFF
--- a/crates/plex-api/src/server/transcode.rs
+++ b/crates/plex-api/src/server/transcode.rs
@@ -601,6 +601,10 @@ fn get_transcode_params<M: MediaItemWithTranscoding>(
 
     let mut query = Query::new()
         .param("session", id)
+        // It's not clear what this parameter is for. Mobile clients send a
+        // hyphenated UUID that differes from the session id
+        // above but using the same id seems to work.
+        .param("X-Plex-Session-Identifier", id)
         .param("path", item_metadata.key.clone())
         .param("mediaIndex", part.media_index.to_string())
         .param("partIndex", part.part_index.to_string())

--- a/crates/plex-api/tests/transcode.rs
+++ b/crates/plex-api/tests/transcode.rs
@@ -273,6 +273,7 @@ mod offline {
                     .query_param("subtitles", "burn")
                     .query_param("protocol", "dash")
                     .query_param_exists("X-Plex-Client-Profile-Extra")
+                    .query_param_exists("X-Plex-Session-Identifier")
                     .matches(|req| {
                         let settings = expand_profile(req);
 
@@ -371,6 +372,7 @@ mod offline {
                     .query_param("videoResolution", "1920x1080")
                     .query_param("protocol", "hls")
                     .query_param_exists("X-Plex-Client-Profile-Extra")
+                    .query_param_exists("X-Plex-Session-Identifier")
                     .matches(|req| {
                         let settings = expand_profile(req);
 
@@ -519,6 +521,7 @@ mod offline {
                     .query_param("subtitles", "burn")
                     .query_param("offlineTranscode", "1")
                     .query_param_exists("X-Plex-Client-Profile-Extra")
+                    .query_param_exists("X-Plex-Session-Identifier")
                     .matches(|req| {
                         let settings = expand_profile(req);
 
@@ -874,6 +877,7 @@ mod offline {
                     .query_param("musicBitrate", "192")
                     .query_param("protocol", "dash")
                     .query_param_exists("X-Plex-Client-Profile-Extra")
+                    .query_param_exists("X-Plex-Session-Identifier")
                     .matches(|req| {
                         let settings = expand_profile(req);
 


### PR DESCRIPTION
I'll freely admit I'm not sure of the specific meaning of this parameter however without it sending a second transcode request while the server is already working on a first makes the server often cancel the first so essentially you can only transcode one thing at a time. But if you send a unique `X-Plex-Session-Identifier` with each request you can transcode multiple things at a time. And it does appear to be a different value to the `session` parameter we already send.