### PR TITLE
chore: update xshell to 0.2.7

### DIFF
--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -13,7 +13,7 @@ independent = true
 [dependencies]
 anyhow = "^1.0"
 flate2 = "^1.0"
-xshell = "^0.2"
+xshell = "^0.2.7"
 xflags = "^0.3"
 uuid = { version = "^1.2", features = ["v4"] }
 plex-api = { path = "../plex-api" }


### PR DESCRIPTION
I get a bunch of warnings from the `cmd!` usage that is fixed in xshell 0.2.7.