### PR TITLE
Update http

### DIFF
--- a/crates/plex-api/Cargo.toml
+++ b/crates/plex-api/Cargo.toml
@@ -21,8 +21,8 @@ quick-xml = { version = "^0.38", features = [ "serialize" ] }
 serde_plain = "^1.0.1"
 serde_repr = "^0.1"
 time = { version = "^0.3", features = ["serde-well-known", "serde-human-readable"] }
-http = "^0.2.8"
-http-serde = "^1.1"
+http = "^1.3.1"
+http-serde = "^2.1.1"
 serde_urlencoded = "^0.7.1"
 thiserror = "^2.0"
 sysinfo = "0.30.1"

--- a/crates/plex-api/src/error.rs
+++ b/crates/plex-api/src/error.rs
@@ -30,6 +30,11 @@ pub enum Error {
         source: http::Error,
     },
     #[error("{source}")]
+    IsahcHttpError {
+        #[from]
+        source: isahc::http::Error,
+    },
+    #[error("{source}")]
     IsahcError {
         #[from]
         source: isahc::Error,

--- a/crates/plex-api/src/isahc_compat.rs
+++ b/crates/plex-api/src/isahc_compat.rs
@@ -1,0 +1,15 @@
+use http::StatusCode;
+use isahc::http as isahc_http;
+
+pub(crate) trait StatusCodeExt {
+    fn as_http_status(&self) -> StatusCode;
+}
+
+impl StatusCodeExt for isahc_http::StatusCode {
+    fn as_http_status(&self) -> StatusCode {
+        // `StatusCode::from_u16` only fails for values outside the valid HTTP
+        // status code range. `isahc` already validates status codes before
+        // constructing them, so this conversion cannot fail in practice.
+        StatusCode::from_u16(self.as_u16()).expect("isahc provided an invalid HTTP status code")
+    }
+}

--- a/crates/plex-api/src/lib.rs
+++ b/crates/plex-api/src/lib.rs
@@ -9,6 +9,7 @@
 //!
 mod error;
 mod http_client;
+mod isahc_compat;
 pub mod media_container;
 mod myplex;
 mod player;

--- a/crates/plex-api/src/myplex/claim_token.rs
+++ b/crates/plex-api/src/myplex/claim_token.rs
@@ -1,6 +1,9 @@
 use std::fmt::Display;
 
-use crate::{http_client::HttpClient, url::MYPLEX_CLAIM_TOKEN_PATH, Error, Result};
+use crate::{
+    http_client::HttpClient, isahc_compat::StatusCodeExt, url::MYPLEX_CLAIM_TOKEN_PATH, Error,
+    Result,
+};
 use http::StatusCode;
 use isahc::AsyncReadResponseExt;
 use serde::{Deserialize, Serialize};
@@ -32,7 +35,7 @@ impl ClaimToken {
     #[tracing::instrument(level = "debug", skip_all)]
     pub async fn new(client: &HttpClient) -> Result<Self> {
         let mut response = client.get(MYPLEX_CLAIM_TOKEN_PATH).send().await?;
-        match response.status() {
+        match response.status().as_http_status() {
             StatusCode::OK => {
                 let token = response.json::<SuccessResponse>().await?.token;
                 Ok(Self {

--- a/crates/plex-api/src/myplex/mod.rs
+++ b/crates/plex-api/src/myplex/mod.rs
@@ -17,6 +17,7 @@ use self::{
 };
 use crate::{
     http_client::{HttpClient, HttpClientBuilder, Request},
+    isahc_compat::StatusCodeExt,
     media_container::server::Feature,
     url::{MYPLEX_SERVERS, MYPLEX_SIGNIN_PATH, MYPLEX_SIGNOUT_PATH, MYPLEX_USER_INFO_PATH},
     Error, Result,
@@ -218,7 +219,7 @@ impl MyPlex {
             .send()
             .await?;
 
-        match response.status() {
+        match response.status().as_http_status() {
             StatusCode::NO_CONTENT => Ok(()),
             _ => Err(Error::from_response(response).await),
         }

--- a/crates/plex-api/src/myplex/pin.rs
+++ b/crates/plex-api/src/myplex/pin.rs
@@ -1,4 +1,5 @@
 use crate::{
+    isahc_compat::StatusCodeExt,
     url::{MYPLEX_PINS, MYPLEX_PINS_LINK},
     Error, HttpClient, Result,
 };
@@ -30,7 +31,7 @@ impl PinManager {
             .send()
             .await?;
 
-        if response.status() == StatusCode::NO_CONTENT {
+        if response.status().as_http_status() == StatusCode::NO_CONTENT {
             Ok(())
         } else {
             Err(Error::from_response(response).await)
@@ -50,7 +51,7 @@ impl PinManager {
             .send()
             .await?;
 
-        if response.status() == StatusCode::CREATED {
+        if response.status().as_http_status() == StatusCode::CREATED {
             let pin = response.json::<PinInfo>().await?;
             Ok(Pin {
                 client: &self.client,

--- a/crates/plex-api/src/myplex/privacy.rs
+++ b/crates/plex-api/src/myplex/privacy.rs
@@ -1,4 +1,6 @@
-use crate::{http_client::HttpClient, url::MYPLEX_PRIVACY_PATH, Error};
+use crate::{
+    http_client::HttpClient, isahc_compat::StatusCodeExt, url::MYPLEX_PRIVACY_PATH, Error,
+};
 use http::StatusCode;
 use serde::Deserialize;
 
@@ -62,7 +64,7 @@ impl Privacy {
             .form(&params)?
             .send()
             .await?;
-        if response.status() == StatusCode::NO_CONTENT {
+        if response.status().as_http_status() == StatusCode::NO_CONTENT {
             self.opt_out_library_stats = opt_out_library_stats;
             self.opt_out_playback = opt_out_playback;
             Ok(())

--- a/crates/plex-api/src/myplex/sharing/friend.rs
+++ b/crates/plex-api/src/myplex/sharing/friend.rs
@@ -1,5 +1,6 @@
 use crate::{
-    myplex::account::RestrictionProfile, url::MYPLEX_INVITES_FRIENDS, Error, HttpClient, Result,
+    isahc_compat::StatusCodeExt, myplex::account::RestrictionProfile, url::MYPLEX_INVITES_FRIENDS,
+    Error, HttpClient, Result,
 };
 use http::StatusCode;
 use isahc::AsyncReadResponseExt;
@@ -98,7 +99,7 @@ impl Friend {
             .send()
             .await?;
 
-        match response.status() {
+        match response.status().as_http_status() {
             StatusCode::OK | StatusCode::NO_CONTENT => {
                 response.consume().await?;
                 Ok(())

--- a/crates/plex-api/src/myplex/webhook.rs
+++ b/crates/plex-api/src/myplex/webhook.rs
@@ -1,4 +1,6 @@
-use crate::{http_client::HttpClient, url::MYPLEX_WEBHOOKS_PATH, Error, Result};
+use crate::{
+    http_client::HttpClient, isahc_compat::StatusCodeExt, url::MYPLEX_WEBHOOKS_PATH, Error, Result,
+};
 use http::{StatusCode, Uri};
 use serde::Deserialize;
 use std::fmt::Debug;
@@ -60,7 +62,7 @@ impl WebhookManager {
             .form(&params)?
             .send()
             .await?;
-        if response.status() == StatusCode::CREATED {
+        if response.status().as_http_status() == StatusCode::CREATED {
             self.webhooks = webhooks;
             Ok(())
         } else {

--- a/crates/plex-api/src/server/library.rs
+++ b/crates/plex-api/src/server/library.rs
@@ -6,6 +6,7 @@ use http::StatusCode;
 use isahc::AsyncReadResponseExt;
 
 use crate::{
+    isahc_compat::StatusCodeExt,
     media_container::{
         server::library::{
             CollectionMetadataSubtype, LibraryType, Media as MediaMetadata, Metadata,
@@ -278,7 +279,7 @@ impl<'a, M: MediaItem> Part<'a, M> {
         }
 
         let mut response = builder.send().await?;
-        match response.status() {
+        match response.status().as_http_status() {
             StatusCode::OK | StatusCode::PARTIAL_CONTENT => {
                 response.copy_to(writer).await?;
                 Ok(())

--- a/crates/plex-api/src/server/mod.rs
+++ b/crates/plex-api/src/server/mod.rs
@@ -14,6 +14,7 @@ use self::{
 use crate::media_container::server::library::LibraryType;
 use crate::{
     http_client::HttpClient,
+    isahc_compat::StatusCodeExt,
     media_container::{
         server::{library::ContentDirectory, MediaProviderFeature, Server as ServerMediaContainer},
         MediaContainerWrapper,
@@ -285,7 +286,7 @@ impl Server {
         );
         let mut response = self.client.post(url).send().await?;
 
-        if response.status() == StatusCode::OK {
+        if response.status().as_http_status() == StatusCode::OK {
             response.consume().await?;
             self.refresh().await
         } else {
@@ -297,7 +298,7 @@ impl Server {
     pub async fn unclaim(self) -> Result<Self> {
         let mut response = self.client.delete(SERVER_MYPLEX_ACCOUNT).send().await?;
 
-        if response.status() == StatusCode::OK {
+        if response.status().as_http_status() == StatusCode::OK {
             response.consume().await?;
             self.refresh().await
         } else {

--- a/crates/plex-api/src/server/transcode.rs
+++ b/crates/plex-api/src/server/transcode.rs
@@ -21,6 +21,7 @@ use uuid::Uuid;
 
 use crate::{
     error,
+    isahc_compat::StatusCodeExt,
     media_container::{
         server::{
             library::{
@@ -641,7 +642,7 @@ async fn transcode_decision(client: &HttpClient, params: &Query) -> Result<Media
         .send()
         .await?;
 
-    let text = match response.status() {
+    let text = match response.status().as_http_status() {
         StatusCode::OK => response.text().await?,
         _ => return Err(crate::Error::from_response(response).await),
     };
@@ -917,7 +918,7 @@ impl TranscodeSession {
         }
         let mut response = builder.send().await?;
 
-        match response.status() {
+        match response.status().as_http_status() {
             StatusCode::OK => {
                 response.copy_to(writer).await?;
                 Ok(())
@@ -962,7 +963,7 @@ impl TranscodeSession {
             .send()
             .await?;
 
-        match response.status() {
+        match response.status().as_http_status() {
             // Sometimes the server will respond not found but still cancel the
             // session.
             StatusCode::OK | StatusCode::NOT_FOUND => Ok(response.consume().await?),
@@ -1013,7 +1014,7 @@ where
         .send()
         .await?;
 
-    match response.status() {
+    match response.status().as_http_status() {
         // Sometimes the server will respond not found but still cancel the
         // session.
         StatusCode::OK => {


### PR DESCRIPTION
## Summary
* Bump the http and http-serde crates in the API crate to their latest releases.
* Add an isahc compatibility layer for status conversions and expose it through the crate interface.
* Refactor the HTTP client to leverage the compat trait, build URIs via strings, and use isahc header values after the dependency upgrade.
* Update MyPlex and server components to evaluate responses via as_http_status() so they remain compatible with the new HTTP stack.
* Extend the shared error enum to report isahc HTTP errors raised by the upgraded APIs.

## Testing
- cargo fmt
- cargo test
- cargo clippy -- -D warnings
- cargo fmt -- --check

------
https://chatgpt.com/codex/tasks/task_e_68dbb711921c8327830bdad7ea7587e9