### PR TITLE
Refactor http client with feature flags

### DIFF
--- a/crates/plex-api/Cargo.toml
+++ b/crates/plex-api/Cargo.toml
@@ -11,7 +11,9 @@ readme = "../../README.md"
 rust-version = "1.86.0"
 
 [dependencies]
-isahc = { version = "^1.7.2", features = ["json", "text-decoding"] }
+http-client = "^0.14"
+isahc = { version = "^1.7.2", features = ["json", "text-decoding"], optional = true }
+reqwest = { version = "^0.12", features = ["json", "stream"], optional = true }
 uuid = { version = "^1.2", features = ["v4", "serde"] }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
@@ -23,6 +25,8 @@ serde_repr = "^0.1"
 time = { version = "^0.3", features = ["serde-well-known", "serde-human-readable"] }
 http = "^1.3.1"
 http-serde = "^2.1.1"
+http-body = "^1.0"
+http-body-util = "^0.1"
 serde_urlencoded = "^0.7.1"
 thiserror = "^2.0"
 sysinfo = "0.30.1"
@@ -32,6 +36,8 @@ enum_dispatch = "^0.3.8"
 secrecy = { version = "^0.10", features = ["serde"] }
 tracing = { version = "^0.1.37", features = ["attributes"] }
 semver = { version = "^1.0.27", features = ["serde"] }
+bytes = "^1.9"
+pin-project = "^1.1"
 
 [build-dependencies]
 serde = { version = "^1.0", features = ["derive"] }
@@ -59,6 +65,8 @@ default-features = false
 features = ["precommit-hook", "run-cargo-test", "run-cargo-clippy", "run-cargo-fmt"]
 
 [features]
+http-client-isahc = ["isahc"]
+http-client-reqwest = ["reqwest"]
 tests_deny_unknown_fields = []
 tests_only_online = []
 tests_only_online_unclaimed_server = ["tests_only_online"]

--- a/crates/plex-cli/Cargo.toml
+++ b/crates/plex-cli/Cargo.toml
@@ -10,7 +10,7 @@ description = "Command line interface for managing Plex Media Server"
 independent = true
 
 [dependencies]
-plex-api = { version = ">= 0.0.10", path = "../plex-api" }
+plex-api = { version = ">= 0.0.10", path = "../plex-api", features = ["http-client-isahc"] }
 tokio = { version = "^1.23", features = ["macros", "rt-multi-thread", "time", "fs"] }
 anyhow = "^1.0"
 xflags = "^0.3"


### PR DESCRIPTION
Abstract the HTTP client using `http-client` crate, making `isahc` and `reqwest` optional features, to allow client choice and improve maintainability.

This refactoring introduces a breaking change as the `isahc` client is no longer directly exposed and requires enabling a feature. A `MIGRATION.md` guide is provided to assist with updating existing codebases.

---
<a href="https://cursor.com/background-agent?bcId=bc-c637acea-5551-426f-8ce3-06139b8a0379"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c637acea-5551-426f-8ce3-06139b8a0379"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

